### PR TITLE
Update elsa-data-bucket s3 policy

### DIFF
--- a/packages/aws-data-buckets/data-buckets-stack.ts
+++ b/packages/aws-data-buckets/data-buckets-stack.ts
@@ -79,7 +79,7 @@ export class DataBucketsStack extends Stack {
       bucket.addToResourcePolicy(
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: ["*"],
+          actions: ["s3:Get*", "s3:List*"],
           principals: [new AnyPrincipal()],
           resources: [bucket.bucketArn, bucket.arnForObjects("*")],
           conditions: {


### PR DESCRIPTION
I think we could limit the action for access point to get and list only?

Trying to get rid for the [SecurityHub S3.6](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-6) warning